### PR TITLE
Fix/clear skip

### DIFF
--- a/commands/clear.js
+++ b/commands/clear.js
@@ -15,11 +15,10 @@ export default {
       return message.channel.send({ embeds: [errorEmbed('Nothing to clear')] });
     }
 
-    guildQueue.songs = [];
+    // remove all items from queue except first (this song might be playing)
+    guildQueue.songs = [guildQueue.songs[0]];
 
-    return message.channel.send({
-      embeds: [defaultEmbed('Cleared the queue')],
-    });
+    message.react('👌');
   },
 
   interaction: async (interaction, client) => {
@@ -32,7 +31,8 @@ export default {
       });
     }
 
-    guildQueue.songs = [];
+    // remove all items from queue except first (this song might be playing)
+    guildQueue.songs = [guildQueue.songs[0]];
 
     return interaction.reply({
       embeds: [defaultEmbed('Cleared the queue')],

--- a/commands/play.js
+++ b/commands/play.js
@@ -214,7 +214,7 @@ async function play(guild, song, connection, client) {
         guildQueue.textChannel.send('No more songs to play');
         leaveVoiceChannel(queue, guild.id);
       }
-    }, 3 * MINUTES);
+    }, 10 * MINUTES);
     return;
   }
 

--- a/commands/play.js
+++ b/commands/play.js
@@ -85,6 +85,7 @@ async function getSong(args, message, voiceChannel, client) {
   let guildQueue = client.queue.get(message.guild.id);
 
   if (!guildQueue) {
+    // add current song?
     const queueContruct = {
       textChannel: message.channel,
       voiceChannel: voiceChannel,

--- a/commands/skip.js
+++ b/commands/skip.js
@@ -17,7 +17,7 @@ export default {
     }
 
     if (guildQueue.audioPlayer) {
-      guildQueue.audioPlayer.stop(); // stop song
+      guildQueue.audioPlayer.stop(); // stop song to trigger next song
     }
 
     message.react('👌');
@@ -33,11 +33,11 @@ export default {
       });
     }
 
-    const songTitle = guildQueue.songs[0].title; // get current song title
     if (guildQueue.audioPlayer) {
-      guildQueue.audioPlayer.stop(); // stop song
+      guildQueue.audioPlayer.stop(); // stop song to trigger next song
     }
 
+    const songTitle = guildQueue.songs[0].title; // get current song title
     return interaction.reply({
       embeds: [defaultEmbed(`Skipped \`${songTitle}\``)],
       ephemeral: false,

--- a/index.js
+++ b/index.js
@@ -74,11 +74,11 @@ client.on('disconnect', () => {
 });
 
 client.on('voiceStateUpdate', (oldState, newState) => {
-  // Disconnect
+  // disconnect
   if (oldState.channelId && !newState.channelId) {
     const guildQueue = client.queue.get(newState.guild.id);
 
-    // Bot was Disconnected
+    // bot was Disconnected
     if (newState.id === client.user.id) {
       // bot gets disconnected from voice channel
       if (guildQueue) {
@@ -86,7 +86,7 @@ client.on('voiceStateUpdate', (oldState, newState) => {
         leaveVoiceChannel(client.queue, newState.guild.id);
       }
     } else {
-      // user gets disconnected from voice channel
+      // other user gets disconnected from voice channel
       if (guildQueue) {
         if (getVoiceUsers(guildQueue) < 2) {
           setTimeout(() => {
@@ -95,7 +95,7 @@ client.on('voiceStateUpdate', (oldState, newState) => {
               guildQueue.textChannel.send('No one in the voice channel');
               leaveVoiceChannel(client.queue, newState.guild.id);
             }
-          }, 3 * MINUTES);
+          }, 5 * MINUTES);
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.7",
+  "version": "1.5.9",
   "description": "Play music on Discord",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "ffmpeg-static": "^4.4.1",
     "libsodium-wrappers": "^0.7.10",
     "node-fetch": "^2.6.7",
-    "youtube-sr": "^4.3.1",
-    "ytdl-core": "4.10.0"
+    "youtube-sr": "^4.3.4",
+    "ytdl-core": "^4.11.2"
   },
   "devDependencies": {
     "nodemon": "^2.0.19"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ specifiers:
   libsodium-wrappers: ^0.7.10
   node-fetch: ^2.6.7
   nodemon: ^2.0.19
-  youtube-sr: ^4.3.1
-  ytdl-core: 4.10.0
+  youtube-sr: ^4.3.4
+  ytdl-core: ^4.11.2
 
 dependencies:
   '@discordjs/opus': 0.8.0
@@ -20,8 +20,8 @@ dependencies:
   ffmpeg-static: 4.4.1
   libsodium-wrappers: 0.7.10
   node-fetch: 2.6.7
-  youtube-sr: 4.3.1
-  ytdl-core: 4.10.0
+  youtube-sr: 4.3.4
+  ytdl-core: 4.11.2
 
 devDependencies:
   nodemon: 2.0.19
@@ -42,8 +42,8 @@ packages:
     resolution: {integrity: sha512-ARy4BUTMU+S0ZI6605NDqfWO+qZqV2d/xfY32z3hVSsd9IaAKJBZ1ILTZLy87oIjW8+gUpQmk9Kt0ZP9bmmd8Q==}
     engines: {node: '>=16.9.0'}
     dependencies:
-      '@sapphire/shapeshift': 3.5.1
-      discord-api-types: 0.37.4
+      '@sapphire/shapeshift': 3.6.0
+      discord-api-types: 0.37.9
       fast-deep-equal: 3.1.3
       ts-mixer: 6.0.1
       tslib: 2.4.0
@@ -91,10 +91,10 @@ packages:
       '@discordjs/collection': 1.1.0
       '@sapphire/async-queue': 1.5.0
       '@sapphire/snowflake': 3.2.2
-      discord-api-types: 0.37.4
+      discord-api-types: 0.37.9
       file-type: 17.1.6
       tslib: 2.4.0
-      undici: 5.9.1
+      undici: 5.10.0
     dev: false
 
   /@discordjs/voice/0.11.0_kj4b63tl655kaqafvjfrgtykda:
@@ -120,8 +120,8 @@ packages:
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
     dev: false
 
-  /@sapphire/shapeshift/3.5.1:
-    resolution: {integrity: sha512-7JFsW5IglyOIUQI1eE0g6h06D/Far6HqpcowRScgCiLSqTf3hhkPWCWotVTtVycnDCMYIwPeaw6IEPBomKC8pA==}
+  /@sapphire/shapeshift/3.6.0:
+    resolution: {integrity: sha512-tu2WLRdo5wotHRvsCkspg3qMiP6ETC3Q1dns1Q5V6zKUki+1itq6AbhMwohF9ZcLoYqg+Y8LkgRRtVxxTQVTBQ==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
     dependencies:
       fast-deep-equal: 3.1.3
@@ -141,14 +141,14 @@ packages:
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
     dev: false
 
-  /@types/node/18.7.9:
-    resolution: {integrity: sha512-0N5Y1XAdcl865nDdjbO0m3T6FdmQ4ijE89/urOHLREyTXbpMWbSafx9y7XIsgWGtwUP2iYTinLyyW3FatAxBLQ==}
+  /@types/node/18.7.17:
+    resolution: {integrity: sha512-0UyfUnt02zIuqp7yC8RYtDkp/vo8bFaQ13KkSEvUAohPOAlnVNbj5Fi3fgPSuwzakS+EvvnnZ4x9y7i6ASaSPQ==}
     dev: false
 
   /@types/ws/8.5.3:
     resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
     dependencies:
-      '@types/node': 18.7.9
+      '@types/node': 18.7.17
     dev: false
 
   /abbrev/1.1.1:
@@ -296,8 +296,8 @@ packages:
     resolution: {integrity: sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg==}
     dev: false
 
-  /discord-api-types/0.37.4:
-    resolution: {integrity: sha512-QgqYlUokWM++hdwvAtgVNLjmFumPBzFy+uWnnfVDiwBXKm+5jXHJPk2lx2eilkv/706UpAJPLSk/uVCY9NocjA==}
+  /discord-api-types/0.37.9:
+    resolution: {integrity: sha512-mAJv7EcDDo6YztR3XSIED2IAHJcAlzWFD31Q2cHLURMKPb0CW0TM/r32HhAHO9uHw74N3cviOzJIZfZVB/e/5A==}
     dev: false
 
   /discord.js/14.3.0:
@@ -309,11 +309,11 @@ packages:
       '@discordjs/rest': 1.1.0
       '@sapphire/snowflake': 3.2.2
       '@types/ws': 8.5.3
-      discord-api-types: 0.37.4
+      discord-api-types: 0.37.9
       fast-deep-equal: 3.1.3
       lodash.snakecase: 4.1.1
       tslib: 2.4.0
-      undici: 5.9.1
+      undici: 5.10.0
       ws: 8.8.1
     transitivePeerDependencies:
       - bufferutil
@@ -861,8 +861,8 @@ packages:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
     dev: true
 
-  /undici/5.9.1:
-    resolution: {integrity: sha512-6fB3a+SNnWEm4CJbgo0/CWR8RGcOCQP68SF4X0mxtYTq2VNN8T88NYrWVBAeSX+zb7bny2dx2iYhP3XHi00omg==}
+  /undici/5.10.0:
+    resolution: {integrity: sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==}
     engines: {node: '>=12.18'}
     dev: false
 
@@ -908,13 +908,13 @@ packages:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: false
 
-  /youtube-sr/4.3.1:
-    resolution: {integrity: sha512-PTR2WJZxe+Cd7+niMdQctm/dudzhF5fwhtpIZfQjY08IZn5C0noj8bJdmXZ9jpyuzxyquKhjJDTTzjpfUztdpw==}
+  /youtube-sr/4.3.4:
+    resolution: {integrity: sha512-olSYcR80XigutCrePEXBX3/RJJrWfonJQj7+/ggBiWU0CzTDLE1q8+lpWTWCG0JpzhzILp/IB/Bq/glGqqr1TQ==}
     dev: false
 
-  /ytdl-core/4.10.0:
-    resolution: {integrity: sha512-RCCoSVTmMeBPH5NFR1fh3nkDU9okvWM0ZdN6plw6I5+vBBZVUEpOt8vjbSgprLRMmGUsmrQZJhvG1CHOat4mLA==}
-    engines: {node: '>=10'}
+  /ytdl-core/4.11.2:
+    resolution: {integrity: sha512-D939t9b4ZzP3v0zDvehR2q+KgG97UTgrTKju3pOPGQcXtl4W6W5z0EpznzcJFu+OOpl7S7Ge8hv8zU65QnxYug==}
+    engines: {node: '>=12'}
     dependencies:
       m3u8stream: 0.8.6
       miniget: 4.2.2


### PR DESCRIPTION
Fix bug where if you cleared the queue and then tried to skip the current song the bot would crash because it couldn't reference the current song title.
bot now keeps the first item in the queue on clear (currently playing song)